### PR TITLE
Remove unused dep simple-git to fix security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "commander": "^9.5.0",
         "fs-extra": "^10.0.0",
         "glob": "^11.0.3",
-        "simple-git": "^2.48.0",
         "ts-node": "^10.9.2"
       },
       "devDependencies": {
@@ -85,17 +84,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@kwsites/file-exists": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1"
-      }
-    },
-    "node_modules/@kwsites/promise-deferred": {
-      "version": "1.1.1",
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -218,21 +206,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/diff": {
@@ -366,10 +339,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "license": "BlueOak-1.0.0"
@@ -420,19 +389,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-git": {
-      "version": "2.48.0",
-      "license": "MIT",
-      "dependencies": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/steveukx/"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "commander": "^9.5.0",
     "fs-extra": "^10.0.0",
     "glob": "^11.0.3",
-    "simple-git": "^2.48.0",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #6 

I went to update the `simple-git` dep, but while I was looking at the code, I noticed that there aren't any users of it at the moment.  So in order to remove the security issue, I've simply removed the dep.

Let me know if this is OK, or if you want to still keep it and jump to a new major version.