### PR TITLE
Added cross-platform compatible git functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "^5.6.2",
     "commander": "^9.5.0",
     "glob": "^11.0.3",
+    "simple-git": "^3.28.0",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -50,7 +50,7 @@ export class Packager {
         // Fall back to current directory
         primaryPath = primaryPath || '.';
         
-        this.repoInfo.gitInfo = getGitInfo(primaryPath);
+        this.repoInfo.gitInfo = await getGitInfo(primaryPath);
         
         const allFilePaths: string[] = [];
         


### PR DESCRIPTION
**Fixes #4**

## Problem
The tool was incorrectly showing "Warning: Not a git repository or unable to retrieve git information" even when running in valid git repositories. This occurred because the previous implementation used `child_process.execSync()` to run git commands, which was unreliable on different operating systems.

## Solution

To solve the problem, I have used the `simple-git` library (v3.28.0) instead of the `child_process.execSync()`. This is more reliable option when using this tool across the platforms. I have converted `getGitInfo` function to have an asynchronous async/await implementation. I have added some comments where needed as well.

## Test
Before running `npm start`, make sure to run:
```bash
npm install
npm run build