### PR TITLE
Add TOML config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Repository Context Packager is a command-line tool designed to analyze local
 - **Smart filtering**: Automatically excludes unnecessary files (node_modules, lock files, documentation)
 - **Multi-language support**: TypeScript, JavaScript, Python, and more
 - **Token estimation**: Calculate LLM token usage for better context management
+- **Configuration File**: Set default options instead of writing every feature
 
 ## Installation
 To install the Repository Context Packager, clone the repository and install the dependencies:
@@ -74,7 +75,17 @@ npm start . --summary
 ```bash
 npm start . --summary --tokens
 ```
+## Configuration File
 
+You can create a `.repoPackager.toml` file in your project root to set default options:
+```toml
+# Example configuration
+output = "my-output.md"
+verbose = false
+tokens = true
+exclude = "*.test.ts,*.spec.ts"
+maxFileSize = 5000
+```
 ## Output Modes
 
 ### Full Mode (Default)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "^5.6.2",
     "commander": "^9.5.0",
     "glob": "^11.0.3",
+    "smol-toml": "^1.4.2",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,26 @@ import { Packager } from './packager';
 import fs from 'fs';
 import chalk from 'chalk';
 import path from 'path';
+import { loadConfig,ConfigOptions } from './config';
+
 
 const program = new Command();
+
+function applyConfigDefaults(cliOptions: any): any{
+  const configDefaults = loadConfig();
+
+  return{
+   output: cliOptions.output || configDefaults.output,
+   include: cliOptions.include || configDefaults.include,
+   exclude: cliOptions.exclude || configDefaults.exclude,
+   tokens : cliOptions.tokens ?? configDefaults.tokens,
+   summary: cliOptions.summary ?? configDefaults.summary,
+   verbose: cliOptions.verbose ?? configDefaults.verbose,
+   maxFileSize: cliOptions.maxFileSize || configDefaults.maxFileSize,
+   maxTokens: cliOptions.maxTokens || configDefaults.maxTokens,
+   recent: cliOptions.recent !== undefined ? cliOptions.recent : configDefaults.recent
+  };
+}
 
 program
   .version('1.0.0')
@@ -28,6 +46,8 @@ program
 
     console.log(chalk.blue.bold('📦 Repository Context Packager'));
     console.log(chalk.gray('━'.repeat(50)));
+
+    options = applyConfigDefaults(options);
 
     const packagerOptions: { include?: string[], exclude?: string[], tokens?: boolean, maxFileSize?: number, maxTokens?: number, summary?: boolean, recent?: number, verbose?: boolean } = {};
     

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,82 @@
+import TOML from "smol-toml"
+import fs from "fs"
+import path from "path"
+
+
+export interface ConfigOptions{
+     output?: string,
+     include?: string,
+     exclude?: string,
+     tokens?: boolean,
+     maxFileSize?: number,
+     maxTokens?: number,
+     summary?: boolean,
+     recent?: number,
+     verbose?: boolean
+}
+
+const CONFIG_FILENAME = '.repoPackager.toml';
+/*
+  Load configuration from TOML config file in the specified directory.
+  Returns empty object if no config file exists.
+  Exits with error if config file exists but cannot be parsed.
+ */
+
+ export function loadConfig(chosenDir:string = process.cwd()){
+     const pathToConfig = path.join(chosenDir,CONFIG_FILENAME);
+
+     if(!fs.existsSync(pathToConfig)){
+       return {};
+     }
+
+     try{
+
+      const fileContent = fs.readFileSync(pathToConfig,"utf-8");
+      const parsed = TOML.parse(fileContent) as any;
+      //Extracting only recognized options and ignoring others
+      const config:ConfigOptions = {};
+      
+      if(typeof parsed.output === "string"){
+       config.output = parsed.output;
+      }
+      
+      if(typeof parsed.include === "string"){
+       config.include = parsed.include;
+      }
+      
+      if(typeof parsed.exclude === "string"){
+       config.exclude = parsed.exclude;
+      }
+      
+      if(typeof parsed.tokens === "boolean"){
+       config.tokens = parsed.tokens;
+      }
+       
+      if(typeof parsed.maxFileSize === "number"){
+       config.maxFileSize = parsed.maxFileSize;
+      }
+      
+      if(typeof parsed.maxTokens === "number"){
+       config.maxTokens = parsed.maxTokens;
+      }
+
+      if (typeof parsed.summary === 'boolean') {
+      config.summary = parsed.summary;
+    }
+    
+    if (typeof parsed.recent === 'number') {
+      config.recent = parsed.recent;
+    }
+    
+    if (typeof parsed.verbose === 'boolean') {
+      config.verbose = parsed.verbose;
+    }
+
+     return config; 
+     }catch(error:any){
+       console.error(`Error: Unable to parse TOML file: ${CONFIG_FILENAME}`);
+       console.error(`Details:${error.message}`);
+       process.exit(1);
+     }
+
+ }


### PR DESCRIPTION
## Changes
This PR adds support for TOML configuration files as requested in #15.

### What's New
- Users can now create a `.repoPackager.toml` file with default options
- CLI arguments override config file values
- Invalid TOML syntax results in clear error message
- Unknown config options are silently ignored

### Implementation
- Added `smol-toml` dependency for TOML parsing
- Created `src/config.ts` with `loadConfig()` function and `ConfigOptions` interface
- Added `applyConfigDefaults()` helper in `cli.ts` to merge config with CLI args
- Less chnage in the current codebase

### Example Config File
```toml
output = "custom-output.md"
verbose = true
tokens = true
exclude = "*.test.ts"
```
### Testing
Create a `.repoPackager.toml` file in the project root with the context below:
```toml
output = "test-config.md"
verbose = true
tokens = true

```
- Run program and test it
`npm run build`
`node dist/cli.js src`

-Test the override
node dist/cli.js src -o overrided.md 

-If toml does not exist , all old features  will work as older version

