### PR TITLE
Add Remote Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,8 +139,8 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 # Tool output files
-output.md
+output*.md
 test_*.md
-
+*.md
 # Package lock files
 bun.lockb

--- a/src/git.ts
+++ b/src/git.ts
@@ -11,15 +11,15 @@ export interface GitInfo {
 export function getGitInfo(repoPath?: string): GitInfo | null {
     try {
         const resolvedPath = repoPath ? path.resolve(repoPath) : process.cwd();
-        
+
         // Check if directory exists
         if (repoPath && !require('fs').existsSync(resolvedPath)) {
             process.stderr.write(`Warning: Directory '${repoPath}' does not exist.\n`);
             return null;
         }
-        
+
         const options = { cwd: resolvedPath, stdio: 'pipe' as const };
-        
+
         // Check if it's a git repository first
         try {
             execSync('git rev-parse --git-dir', options);
@@ -27,7 +27,7 @@ export function getGitInfo(repoPath?: string): GitInfo | null {
             process.stderr.write(`Warning: '${resolvedPath}' is not a git repository.\n`);
             return null;
         }
-        
+
         const commit = execSync('git rev-parse HEAD', options).toString().trim();
         const branch = execSync('git rev-parse --abbrev-ref HEAD', options).toString().trim();
         const author = execSync('git log -1 --pretty=format:\'%an <%ae>\'', options).toString().trim();
@@ -43,5 +43,13 @@ export function getGitInfo(repoPath?: string): GitInfo | null {
             process.stderr.write(`Warning: Unable to retrieve git information: ${error.message}\n`);
         }
         return null;
+    }
+}
+
+export function cloneRepository(url: string, targetDir: string): void {
+    try {
+        execSync(`git clone --depth 1 ${url} ${targetDir}`, { stdio: 'pipe' });
+    } catch (error: any) {
+        throw new Error(`Failed to clone repository: ${error.message}`);
     }
 }


### PR DESCRIPTION
**Description**
This PR adds the ability to pass a GitHub URL directly to the CLI. The tool will now clone the repository to a temporary directory, package its context, and then clean up the temporary files. Closing #20 

**Motivation**

Currently, users must manually clone a repository before they can package it. This feature reduces friction and allows for quick analysis of open source tools by simply providing the URL.

**Changes**

CLI Argument Parsing: Updated src/cli.ts to detect if the first argument is a GitHub URL.
Git Cloning: Added cloneRepository function in src/git.ts to handle cloning using git clone --depth 1.
Cleanup: Implemented automatic cleanup of the temporary directory in src/cli.ts using a finally block.
 
**Verification**:

- Tested with a valid GitHub URL: npm start -- https://github.com/abdulgafar4/repo-context packager -o output_remote.md -> Success.
- Tested with an invalid GitHub URL: npm start -- https://github.com/invalid/url -> Handled gracefully with an error message.
- Tested with local paths to ensure existing functionality remains intact.